### PR TITLE
fixed request header bug in api class

### DIFF
--- a/classes/local/api.php
+++ b/classes/local/api.php
@@ -160,6 +160,7 @@ class api extends \curl {
 
         $url = $this->baseurl . $resource;
 
+        $this->resetHeader();
         $header = $this->get_authentication_header($runwithroles);
         $header[] = 'Content-Type: application/json';
         $this->setHeader($header);
@@ -236,8 +237,8 @@ class api extends \curl {
 
         $url = $this->baseurl . $resource;
 
+        $this->resetHeader();
         $header = $this->get_authentication_header($runwithroles);
-
         $header[] = "Content-Type: multipart/form-data";
         $this->setHeader($header);
         $this->setopt(array('CURLOPT_HEADER' => false));
@@ -278,6 +279,7 @@ class api extends \curl {
 
         $url = $this->baseurl . $resource;
 
+        $this->resetHeader();
         $header = $this->get_authentication_header($runwithroles);
         $this->setHeader($header);
         $this->setopt(array('CURLOPT_HEADER' => false));
@@ -312,6 +314,7 @@ class api extends \curl {
 
         $url = $this->baseurl . $resource;
 
+        $this->resetHeader();
         $header = $this->get_authentication_header($runwithroles);
         $this->setHeader($header);
         $this->setopt(array('CURLOPT_HEADER' => false));


### PR DESCRIPTION
When using oc_get and oc_post on the same api object the second call
would use some header fields set by the first so it would fail.

Fixes #24