### PR TITLE
Updated api __constructor (distributed oc) 

### DIFF
--- a/classes/local/api.php
+++ b/classes/local/api.php
@@ -131,13 +131,18 @@ class api extends \curl {
      * @throws \dml_exception
      * @throws \moodle_exception
      */
-    public function __construct($settings = array()) {
+    public function __construct($settings = array(), $baseurl = null) {
         parent::__construct($settings);
 
         $this->username = get_config('tool_opencast', 'apiusername');
-        $this->password = get_config('tool_opencast', 'apipassword');;
-        $this->timeout = get_config('tool_opencast', 'apitimeout');;
-        $this->baseurl = get_config('tool_opencast', 'apiurl');
+        $this->password = get_config('tool_opencast', 'apipassword');
+        $this->timeout = get_config('tool_opencast', 'apitimeout');
+        if ($baseurl == null) {
+            $this->baseurl = get_config('tool_opencast', 'apiurl');
+        } else {
+            $this->baseurl = $baseurl;
+        }
+        
         if (empty($this->baseurl)) {
             throw new \moodle_exception('apiurlempty', 'tool_opencast');
         }

--- a/classes/local/api.php
+++ b/classes/local/api.php
@@ -128,6 +128,7 @@ class api extends \curl {
     /**
      * Constructor of the Opencast API.
      * @param array $settings additional curl settings.
+     * @param string|null $baseurl optional baseurl for distributed oc solution
      * @throws \dml_exception
      * @throws \moodle_exception
      */


### PR DESCRIPTION
Distributed oc may have different api endpoints which can lead to errors when trying to load an oc request from the "engament" api.
This was detected while setting up the https://github.com/Opencast-Moodle/moodle-local_och5p/blob/master/ajax.php#L103.