### PR TITLE
Improve first-time admin user experience - Solves #11, solves #15.

### DIFF
--- a/classes/local/api.php
+++ b/classes/local/api.php
@@ -139,6 +139,12 @@ class api extends \curl {
         $this->password = get_config('tool_opencast', 'apipassword');;
         $this->timeout = get_config('tool_opencast', 'apitimeout');;
         $this->baseurl = get_config('tool_opencast', 'apiurl');
+
+        // If the admin omitted the protocol part, add the HTTPS protocol on-the-fly.
+        if (!preg_match('/^https?:\/\//', $this->baseurl)) {
+            $this->baseurl = 'https://'.$this->baseurl;
+        }
+
         if (empty($this->baseurl)) {
             throw new empty_configuration_exception('apiurlempty', 'tool_opencast');
         }

--- a/lang/en/tool_opencast.php
+++ b/lang/en/tool_opencast.php
@@ -27,27 +27,26 @@ defined('MOODLE_INTERNAL') || die();
 
 $string['pluginname'] = 'Opencast API';
 
-$string['apipassword'] = 'Password for API user';
-$string['apipassworddesc'] = 'Setup a password for the super user, who does the api calls.';
-$string['apipasswordempty'] = 'Password for API user is not setup correctly, go to settings of tool opencast to fix this';
-$string['apiurl'] = 'Opencast API url';
-$string['apiurldesc'] = 'Setup the base url of the Opencast system, for example: opencast.example.com';
-$string['apiurlempty'] = 'Url for Opencast API is not setup correctly, go to settings of tool opencast to fix this';
-$string['apiusername'] = 'Username for API calls';
-$string['apiusernamedesc'] = 'For all calls to the API moodle uses this user. Authorization is done by adding suitable roles to the call';
-$string['apiusernameempty'] = 'Username for Opencast API user is not setup correctly, go to settings of tool opencast to fix this';
+$string['apipassword'] = 'Password of Opencast API user';
+$string['apipassworddesc'] = 'Configure the password of the Opencast user who is used to do the Opencast API calls.';
+$string['apipasswordempty'] = 'Password of Opencast API user is not configured correctly. Go to the settings of the Opencast API tool to fix this.';
+$string['apiurl'] = 'Opencast API URL';
+$string['apiurldesc'] = 'Configure the base URL of the Opencast system. A valid URL is required here. If you omit the protocol part here, \'https://\' is added on-the-fly when doing Opencast API calls.';
+$string['apiurlempty'] = 'URL of Opencast API is not configured correctly. Go to the settings of the Opencast API tool to fix this.';
+$string['apiusername'] = 'Username of Opencast API user';
+$string['apiusernamedesc'] = 'Configure the username of the Opencast user who is used to do the Opencast API calls. Moodle uses this Opencast user for all communication with Opencast. Authorization is done by adding suitable roles to the call.';
+$string['apiusernameempty'] = 'Username of Opencast API user is not configured correctly. Go to the settings of the Opencast API tool to fix this.';
 $string['connecttimeout'] = 'Connection timeout';
-$string['connecttimeoutdesc'] = 'Setup the time in seconds while moodle is trying to connect to opencast until timeout';
+$string['connecttimeoutdesc'] = 'Configure the time in seconds while Moodle is trying to connect to Opencast. If Opencast does not answer within this time, the connection attempt times out.';
+$string['demoservernotification'] = 'The Opencast API tool is currently configured to connect to the <a href="https://stable.opencast.org">public Opencast demo server</a>. You can use this Opencast server for evaluating this plugin.<br />Do not use it for any production purposes. Please <a href="https://docs.opencast.org/">setup your own Opencast server</a> instead.';
 
-$string['opencast:externalapi'] = 'Access to tool_opencast webservices';
-$string['opencast:instructor'] = 'Gives the role of an instructor in opencast';
-$string['opencast:learner'] = 'Gives the role of a learner in opencast';
+$string['opencast:externalapi'] = 'Access to Opencast API webservices';
+$string['opencast:instructor'] = 'Gives the role of an instructor in Opencast';
+$string['opencast:learner'] = 'Gives the role of a learner in Opencast';
 
 $string['needphp55orhigher'] = 'PHP Version 5.5 or higher is needed';
-$string['wrongmimetypedetected'] = 'Wrong mimetype was detected, while trying to upload {$a->filename} from course {$a->coursename},
-    You can only upload video files!';
-$string['serverconnectionerror'] = 'There was a problem with the connection to the opencast server. Please check your credentials and your network settings.';
+$string['wrongmimetypedetected'] = 'Wrong mimetype was detected, while trying to upload {$a->filename} from course {$a->coursename}. You can only upload video files!';
+$string['serverconnectionerror'] = 'There was a problem with the connection to the Opencast server. Please check your Opencast API credentials and your network settings.';
 
 // Privacy API.
-$string['privacy:metadata'] = 'The admin tool only provides API endpoints and general settings for the set of opencast plugin.
-It saves, which opencast series belongs to which course, but it does not store any personal data.';
+$string['privacy:metadata'] = 'The Opencast API admin tool only provides API endpoints and general settings for the set of Opencast plugins. It stores which Opencast series belongs to which Moodle course, but it does not store any personal data.';

--- a/settings.php
+++ b/settings.php
@@ -25,16 +25,24 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+global $OUTPUT;
+
 if ($hassiteconfig) {
 
     $settings = new admin_settingpage('tool_opencast', new lang_string('pluginname', 'tool_opencast'));
 
+    // Show a notification banner if the plugin is connected to the Opencast demo server.
+    if (strpos(get_config('tool_opencast', 'apiurl'), 'stable.opencast.org') !== false) {
+        $demoservernotification = $OUTPUT->notification(get_string('demoservernotification', 'tool_opencast'), \core\output\notification::NOTIFY_WARNING);
+        $settings->add(new admin_setting_heading('tool_opencast/demoservernotification', '', $demoservernotification));
+    }
+
     $settings->add(new admin_setting_configtext('tool_opencast/apiurl', get_string('apiurl', 'tool_opencast'),
-        get_string('apiurldesc', 'tool_opencast'), 'moodle-proxy.rz.tu-ilmenau.de'));
+        get_string('apiurldesc', 'tool_opencast'), 'https://stable.opencast.org', PARAM_URL));
     $settings->add(new admin_setting_configtext('tool_opencast/apiusername', get_string('apiusername', 'tool_opencast'),
-        get_string('apiusernamedesc', 'tool_opencast'), ''));
+        get_string('apiusernamedesc', 'tool_opencast'), 'admin'));
     $settings->add(new admin_setting_configpasswordunmask('tool_opencast/apipassword', get_string('apipassword', 'tool_opencast'),
-        get_string('apipassworddesc', 'tool_opencast'), ''));
+        get_string('apipassworddesc', 'tool_opencast'), 'opencast'));
     $settings->add(new admin_setting_configduration('tool_opencast/connecttimeout', get_string('connecttimeout', 'tool_opencast'),
         get_string('connecttimeoutdesc', 'tool_opencast'), 1));
 


### PR DESCRIPTION
This patch improves the first-time admin user experience of this plugin as well as the understandability and stability of its admin settings.

The changes are as follows:
* Change the default connection settings to use the public Opencast demo server stable.opencast.org instead of the TU Ilmenau server. With this change, the plugin can directly be evaluated without setting up Opencast before.
* Add a notification to the admin settings page that the Opencast demo server is not to be used in production.
* Add a parameter verification to make sure that the Opencast base URL complies to PARAM_URL.
* As PARAM_URL allows to omit the protocol part, add https:// on-the-fly to make sure that the plugin communicates correctly with Opencast without running into HTTP->HTTPS redirects.
* Polish the existing language pack strings for better understandability.