### PR TITLE
Mark old cURL methods as deprecated

### DIFF
--- a/classes/local/api.php
+++ b/classes/local/api.php
@@ -420,7 +420,8 @@ class api extends \curl {
      */
     public function oc_get($resource, $runwithroles = []) {
 
-        throw new \coding_exception(__FUNCTION__ . '() has been removed.');
+        throw new \coding_exception(__FUNCTION__ . '() has been marked as deprecated,' .
+            ' please use "Opencast PHP Library" via `opencastapi` property instead.');
         // Check for maintenance first.
         if (!empty($this->maintenance) && !$this->maintenance->can_access(__FUNCTION__)) {
             return $this->maintenance->decide_access_bounce();
@@ -527,8 +528,8 @@ class api extends \curl {
      */
     public function oc_post($resource, $params = [], $runwithroles = []) {
 
-        throw new \coding_exception(__FUNCTION__ . '() has been removed.');
-
+        throw new \coding_exception(__FUNCTION__ . '() has been marked as deprecated,' .
+            ' please use "Opencast PHP Library" via `opencastapi` property instead.');
         // Check for maintenance first.
         if (!empty($this->maintenance) && !$this->maintenance->can_access(__FUNCTION__)) {
             return $this->maintenance->decide_access_bounce();
@@ -581,8 +582,8 @@ class api extends \curl {
      */
     public function oc_put($resource, $params = [], $runwithroles = []) {
 
-        throw new \coding_exception(__FUNCTION__ . '() has been removed.');
-
+        throw new \coding_exception(__FUNCTION__ . '() has been marked as deprecated,' .
+            ' please use "Opencast PHP Library" via `opencastapi` property instead.');
         // Check for maintenance first.
         if (!empty($this->maintenance) && !$this->maintenance->can_access(__FUNCTION__)) {
             return $this->maintenance->decide_access_bounce();
@@ -625,7 +626,8 @@ class api extends \curl {
      */
     public function oc_delete($resource, $params = [], $runwithroles = []) {
 
-        throw new \coding_exception(__FUNCTION__ . '() has been removed.');
+        throw new \coding_exception(__FUNCTION__ . '() has been marked as deprecated,' .
+            ' please use "Opencast PHP Library" via `opencastapi` property instead.');
 
         // Check for maintenance first.
         if (!empty($this->maintenance) && !$this->maintenance->can_access(__FUNCTION__)) {

--- a/classes/local/api.php
+++ b/classes/local/api.php
@@ -415,9 +415,12 @@ class api extends \curl {
      * the specified roles.
      * @return string JSON String of result.
      * @throws \moodle_exception
+     * @throws \coding_exception
+     * @deprecated since v4.5-r4.
      */
     public function oc_get($resource, $runwithroles = []) {
 
+        throw new \coding_exception(__FUNCTION__ . '() has been removed.');
         // Check for maintenance first.
         if (!empty($this->maintenance) && !$this->maintenance->can_access(__FUNCTION__)) {
             return $this->maintenance->decide_access_bounce();
@@ -519,8 +522,12 @@ class api extends \curl {
      * the specified roles.
      * @return string JSON String of result.
      * @throws \moodle_exception
+     * @throws \coding_exception
+     * @deprecated since v4.5-r4.
      */
     public function oc_post($resource, $params = [], $runwithroles = []) {
+
+        throw new \coding_exception(__FUNCTION__ . '() has been removed.');
 
         // Check for maintenance first.
         if (!empty($this->maintenance) && !$this->maintenance->can_access(__FUNCTION__)) {
@@ -569,8 +576,12 @@ class api extends \curl {
      * the specified roles.
      * @return string JSON String of result.
      * @throws \moodle_exception
+     * @throws \coding_exception
+     * @deprecated since v4.5-r4.
      */
     public function oc_put($resource, $params = [], $runwithroles = []) {
+
+        throw new \coding_exception(__FUNCTION__ . '() has been removed.');
 
         // Check for maintenance first.
         if (!empty($this->maintenance) && !$this->maintenance->can_access(__FUNCTION__)) {
@@ -609,8 +620,12 @@ class api extends \curl {
      * the specified roles.
      * @return string JSON String of result.
      * @throws \moodle_exception
+     * @throws \coding_exception
+     * @deprecated since v4.5-r4.
      */
     public function oc_delete($resource, $params = [], $runwithroles = []) {
+
+        throw new \coding_exception(__FUNCTION__ . '() has been removed.');
 
         // Check for maintenance first.
         if (!empty($this->maintenance) && !$this->maintenance->can_access(__FUNCTION__)) {


### PR DESCRIPTION
This PR fixes #79,

It is simply to mark the `oc_get`, `oc_post`, `oc_put` and `oc_delete` methods as deprecated and to throw code_exception when using it!

Throwing exception helps developers to know what is going on!