### PR TITLE
Rename page title

### DIFF
--- a/addactivity.php
+++ b/addactivity.php
@@ -48,9 +48,9 @@ $redirecturlcourse = new moodle_url('/course/view.php', ['id' => $courseid]);
 require_login($courseid, false);
 
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturloverview);
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturloverview);
 $PAGE->navbar->add(get_string('addactivity_addbuttontitle', 'tool_opencast'), $baseurl);
 
 // Check if the Opencast Activity module feature is enabled and working.

--- a/addactivityepisode.php
+++ b/addactivityepisode.php
@@ -47,9 +47,9 @@ $redirecturlcourse = new moodle_url('/course/view.php', ['id' => $courseid]);
 require_login($courseid, false);
 
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturloverview);
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturloverview);
 $PAGE->navbar->add(get_string('addactivityepisode_addicontitle', 'tool_opencast'), $baseurl);
 
 // Check if the Opencast Activity module feature is enabled and working.

--- a/addlti.php
+++ b/addlti.php
@@ -53,9 +53,9 @@ require_login($courseid, false);
 
 // Set page and navbar properties.
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturloverview);
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturloverview);
 $PAGE->navbar->add(get_string('addlti_addbuttontitle', 'tool_opencast'), $baseurl);
 
 // Check if the LTI module feature is enabled and working.

--- a/addltiepisode.php
+++ b/addltiepisode.php
@@ -53,9 +53,9 @@ require_login($courseid, false);
 
 // Set page and navbar properties.
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturloverview);
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturloverview);
 $PAGE->navbar->add(get_string('addltiepisode_addicontitle', 'tool_opencast'), $baseurl);
 
 // Check if the LTI module feature is enabled and working.

--- a/addtranscription.php
+++ b/addtranscription.php
@@ -49,9 +49,9 @@ $PAGE->set_url($baseurl);
 require_login($courseid, false);
 
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $indexurl);
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $indexurl);
 $PAGE->navbar->add(get_string('managetranscriptions', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('addnewtranscription', 'tool_opencast'), $baseurl);
 

--- a/addvideo.php
+++ b/addvideo.php
@@ -69,8 +69,8 @@ $PAGE->set_context($pagecontext);
 
 $PAGE->set_pagelayout('incourse');
 $PAGE->set_title(get_string('addvideo', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturl);
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('addvideo', 'tool_opencast'), $baseurl);
 
 // Capability check.

--- a/batchupload.php
+++ b/batchupload.php
@@ -75,8 +75,8 @@ $PAGE->set_context($pagecontext);
 
 $PAGE->set_pagelayout('incourse');
 $PAGE->set_title(get_string('batchupload', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturl);
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('batchupload', 'tool_opencast'), $baseurl);
 
 // Capability check.

--- a/changeowner.php
+++ b/changeowner.php
@@ -104,9 +104,9 @@ if (!$isowner &&
     throw new moodle_exception(get_string('userisntowner', 'tool_opencast'));
 } else {
     $PAGE->set_pagelayout('incourse');
-    $PAGE->set_title(get_string('pluginname', 'tool_opencast'));
-    $PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
-    $PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturl);
+    $PAGE->set_title(get_string('servicename', 'tool_opencast'));
+    $PAGE->set_heading(get_string('servicename', 'tool_opencast'));
+    $PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturl);
     $PAGE->navbar->add(get_string('changeowner', 'tool_opencast'), $baseurl);
 
     $excludeusers = [];

--- a/changescheduledvisibility.php
+++ b/changescheduledvisibility.php
@@ -44,11 +44,11 @@ $PAGE->set_url($baseurl);
 require_login($courseid, false);
 
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
 
 $redirecturl = new moodle_url('/admin/tool/opencast/index.php', ['courseid' => $courseid, 'ocinstanceid' => $ocinstanceid]);
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturl);
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('changescheduledvisibilityheader', 'tool_opencast'), $baseurl);
 
 // Check if the ACL control feature is enabled.

--- a/changevisibility.php
+++ b/changevisibility.php
@@ -45,11 +45,11 @@ $PAGE->set_url($baseurl);
 require_login($courseid, false);
 
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
 
 $redirecturl = new moodle_url('/admin/tool/opencast/index.php', ['courseid' => $courseid, 'ocinstanceid' => $ocinstanceid]);
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturl);
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('changevisibility', 'tool_opencast'), $baseurl);
 
 // Check if the ACL control feature is enabled.

--- a/changevisibility_massaction.php
+++ b/changevisibility_massaction.php
@@ -47,11 +47,11 @@ $PAGE->set_url($baseurl);
 require_login($courseid, false);
 
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
 
 $redirecturl = new moodle_url('/admin/tool/opencast/index.php', ['courseid' => $courseid, 'ocinstanceid' => $ocinstanceid]);
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturl);
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('changevisibility_massaction', 'tool_opencast'), $baseurl);
 
 // Check if the ACL control feature is enabled.

--- a/deleteaclgroup.php
+++ b/deleteaclgroup.php
@@ -41,11 +41,11 @@ $PAGE->set_url($baseurl);
 require_login($courseid, false);
 
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
 
 $redirecturl = new moodle_url('/admin/tool/opencast/index.php', ['courseid' => $courseid, 'ocinstanceid' => $ocinstanceid]);
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturl);
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('deleteaclgroup', 'tool_opencast'), $baseurl);
 
 // Capability check.

--- a/deletedraft.php
+++ b/deletedraft.php
@@ -46,8 +46,8 @@ $PAGE->set_url($baseurl);
 require_login($courseid, false);
 
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
 
 if ($redirectpage == 'overviewvideos') {
     $redirecturl = new moodle_url('/admin/tool/opencast/overview_videos.php', ['ocinstanceid' => $ocinstanceid,
@@ -56,7 +56,7 @@ if ($redirectpage == 'overviewvideos') {
     $redirecturl = new moodle_url('/admin/tool/opencast/index.php', ['courseid' => $courseid, 'ocinstanceid' => $ocinstanceid]);
 }
 
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturl);
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('deletedraft', 'tool_opencast'), $baseurl);
 
 // Capability check.

--- a/deleteevent.php
+++ b/deleteevent.php
@@ -44,8 +44,8 @@ $PAGE->set_url($baseurl);
 require_login($courseid, false);
 
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
 
 if ($redirectpage == 'overviewvideos') {
     $redirecturl = new moodle_url('/admin/tool/opencast/overview_videos.php', ['ocinstanceid' => $ocinstanceid,
@@ -56,7 +56,7 @@ if ($redirectpage == 'overviewvideos') {
     $redirecturl = new moodle_url('/admin/tool/opencast/index.php', ['courseid' => $courseid, 'ocinstanceid' => $ocinstanceid]);
 }
 
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturl);
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('deleteevent', 'tool_opencast'), $baseurl);
 
 // Capability check.

--- a/deleteevent_massaction.php
+++ b/deleteevent_massaction.php
@@ -45,8 +45,8 @@ $PAGE->set_url($baseurl);
 require_login($courseid, false);
 
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
 
 if ($redirectpage == 'overviewvideos') {
     $redirecturl = new moodle_url('/admin/tool/opencast/overview_videos.php', ['ocinstanceid' => $ocinstanceid,
@@ -57,7 +57,7 @@ if ($redirectpage == 'overviewvideos') {
     $redirecturl = new moodle_url('/admin/tool/opencast/index.php', ['courseid' => $courseid, 'ocinstanceid' => $ocinstanceid]);
 }
 
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturl);
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('deleteevent_massaction', 'tool_opencast'), $baseurl);
 
 // Capability check.

--- a/deletetranscription.php
+++ b/deletetranscription.php
@@ -49,9 +49,9 @@ $PAGE->set_url($baseurl);
 require_login($courseid, false);
 
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $indexurl);
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $indexurl);
 $PAGE->navbar->add(get_string('managetranscriptions', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('deletetranscription', 'tool_opencast'), $baseurl);
 

--- a/directaccess.php
+++ b/directaccess.php
@@ -49,8 +49,8 @@ require_login($courseid, false);
 
 $PAGE->set_pagelayout('incourse');
 $PAGE->set_title(get_string('directaccesstovideo', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturl);
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('directaccesstovideo', 'tool_opencast'), $baseurl);
 
 // Capability check.

--- a/downloadtranscription.php
+++ b/downloadtranscription.php
@@ -52,8 +52,8 @@ require_login($courseid, false);
 
 $PAGE->set_pagelayout('popup');
 $PAGE->set_title(get_string('downloadtranscription', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $indexurl);
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $indexurl);
 $PAGE->navbar->add(get_string('managetranscriptions', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('downloadtranscription', 'tool_opencast'), $baseurl);
 

--- a/downloadvideo.php
+++ b/downloadvideo.php
@@ -45,8 +45,8 @@ require_login($courseid, false);
 
 $PAGE->set_pagelayout('incourse');
 $PAGE->set_title(get_string('addvideo', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturl);
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('addvideo', 'tool_opencast'), $baseurl);
 
 // Capability check.

--- a/engageredirect.php
+++ b/engageredirect.php
@@ -49,7 +49,7 @@ $context = context_course::instance($courseid);
 $PAGE->set_context($context);
 $PAGE->set_pagelayout('incourse');
 $PAGE->set_title(get_string('engageredirect', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
 
 $endpoint = get_config('tool_opencast', 'engageurl_' . $ocinstanceid);
 

--- a/importvideos.php
+++ b/importvideos.php
@@ -72,9 +72,9 @@ require_login($courseid, false);
 
 // Set page and navbar properties.
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturloverview);
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturloverview);
 $PAGE->navbar->add(get_string('importvideos_importbuttontitle', 'tool_opencast'), $baseurl);
 
 // Check if the manual import videos feature is enabled and working.

--- a/index.php
+++ b/index.php
@@ -32,6 +32,7 @@ use tool_opencast\local\upload_helper;
 use tool_opencast\exception\opencast_api_response_exception;
 use core\notification;
 use tool_opencast\local\settings_api;
+
 require_once('../../../config.php');
 require_once($CFG->dirroot . '/lib/tablelib.php');
 
@@ -92,12 +93,12 @@ $PAGE->requires->js_call_amd('tool_opencast/block_massaction', 'init',
     ]
 );
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
 
 if (settings_api::num_ocinstances() > 1) {
-    $PAGE->set_heading(get_string('pluginname', 'tool_opencast') . ': ' . settings_api::get_ocinstance($ocinstanceid)->name);
+    $PAGE->set_heading(get_string('servicename', 'tool_opencast') . ': ' . settings_api::get_ocinstance($ocinstanceid)->name);
 } else {
-    $PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
+    $PAGE->set_heading(get_string('servicename', 'tool_opencast'));
 }
 
 $PAGE->navbar->add(get_string('overview', 'tool_opencast'), $baseurl);

--- a/lang/en/tool_opencast.php
+++ b/lang/en/tool_opencast.php
@@ -866,6 +866,7 @@ $string['seriesoverview'] = 'Series overview';
 $string['seriesoverviewexplanation'] = 'Here you can see all series that are used in any course where you have the permission to manage videos.<br>Series might be manageable by the block in the course and/or might be provided as activity to the students.';
 $string['seriesoverviewof'] = 'Series overview of {$a} instance';
 $string['serverconnectionerror'] = 'There was a problem with the connection to the Opencast server. Please check your Opencast API credentials and your network settings.';
+$string['servicename'] = 'Opencast';
 $string['setdefaultseries'] = 'Do you really want to use this series as new default series?';
 $string['setdefaultseries_heading'] = 'Set default series';
 $string['setdefaultseriesfailed'] = 'Changing the default series failed. Please try again later or contact an administrator.';

--- a/lib.php
+++ b/lib.php
@@ -37,7 +37,7 @@ use tool_opencast\seriesmapping;
 function tool_opencast_extend_navigation_course($navigation, $course, $context) {
     if (has_capability('tool/opencast:addactivity', $context)) {
         $url = new moodle_url('/admin/tool/opencast/index.php', ['courseid' => $course->id]);
-        $navigation->add(get_string('pluginname', 'tool_opencast'), $url, navigation_node::TYPE_COURSE,
+        $navigation->add(get_string('servicename', 'tool_opencast'), $url, navigation_node::TYPE_COURSE,
         null, null, new pix_icon('i/report', ''));
     }
 }

--- a/managedefaults.php
+++ b/managedefaults.php
@@ -60,8 +60,8 @@ $PAGE->set_context(context_system::instance());
 
 $PAGE->set_pagelayout('incourse');
 $PAGE->set_title(get_string('managedefaultsforuser', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturl);
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('managedefaultsforuser', 'tool_opencast'), $baseurl);
 
 // Capability check.

--- a/manageseries.php
+++ b/manageseries.php
@@ -59,13 +59,13 @@ $redirecturl = new moodle_url('/admin/tool/opencast/index.php', ['courseid' => $
 require_login($courseid, false);
 
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
 if (settings_api::num_ocinstances() > 1) {
-    $PAGE->set_heading(get_string('pluginname', 'tool_opencast') . ': ' . settings_api::get_ocinstance($ocinstanceid)->name);
+    $PAGE->set_heading(get_string('servicename', 'tool_opencast') . ': ' . settings_api::get_ocinstance($ocinstanceid)->name);
 } else {
-    $PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
+    $PAGE->set_heading(get_string('servicename', 'tool_opencast'));
 }
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturl);
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('manageseriesforcourse', 'tool_opencast'), $baseurl);
 
 // Capability check.

--- a/managetranscriptions.php
+++ b/managetranscriptions.php
@@ -44,9 +44,9 @@ $PAGE->set_url($baseurl);
 require_login($courseid, false);
 
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturl);
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('managetranscriptions', 'tool_opencast'), $baseurl);
 
 // Capability check.

--- a/overview.php
+++ b/overview.php
@@ -43,7 +43,7 @@ $PAGE->set_context(context_system::instance());
 
 require_login(get_course($SITE->id), false);
 $PAGE->set_pagelayout('standard');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
 
 $courses = get_user_capability_course('tool/opencast:viewunpublishedvideos');
 
@@ -51,9 +51,9 @@ $apibridge = apibridge::get_instance($ocinstanceid);
 $opencasterror = null;
 
 if (settings_api::num_ocinstances() > 1) {
-    $PAGE->set_heading(get_string('pluginname', 'tool_opencast') . ': ' . settings_api::get_ocinstance($ocinstanceid)->name);
+    $PAGE->set_heading(get_string('servicename', 'tool_opencast') . ': ' . settings_api::get_ocinstance($ocinstanceid)->name);
 } else {
-    $PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
+    $PAGE->set_heading(get_string('servicename', 'tool_opencast'));
 }
 
 $PAGE->navbar->add(get_string('opencastseries', 'tool_opencast'), $baseurl);

--- a/overview_videos.php
+++ b/overview_videos.php
@@ -42,15 +42,15 @@ $PAGE->set_context(context_system::instance());
 
 require_login(get_course($SITE->id), false);
 $PAGE->set_pagelayout('standard');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
 
 $apibridge = apibridge::get_instance($ocinstanceid);
 $opencasterror = null;
 
 if (settings_api::num_ocinstances() > 1) {
-    $PAGE->set_heading(get_string('pluginname', 'tool_opencast') . ': ' . settings_api::get_ocinstance($ocinstanceid)->name);
+    $PAGE->set_heading(get_string('servicename', 'tool_opencast') . ': ' . settings_api::get_ocinstance($ocinstanceid)->name);
 } else {
-    $PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
+    $PAGE->set_heading(get_string('servicename', 'tool_opencast'));
 }
 
 /** @var tool_opencast_renderer $renderer */
@@ -110,7 +110,7 @@ $isseriesowner = $ocseries && ($apibridge->is_owner($ocseries->acl, $USER->id, $
 
 $PAGE->navbar->add(get_string('opencastseries', 'tool_opencast'),
     new moodle_url('/admin/tool/opencast/overview.php', ['ocinstanceid' => $ocinstanceid]));
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $baseurl);
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $baseurl);
 $PAGE->requires->js_call_amd('tool_opencast/block_massaction', 'init',
     [
         $SITE->id,

--- a/recordvideo.php
+++ b/recordvideo.php
@@ -49,7 +49,7 @@ $PAGE->set_context($context);
 
 $PAGE->set_pagelayout('incourse');
 $PAGE->set_title(get_string('recordvideo', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
 
 $endpoint = settings_api::get_apiurl($ocinstanceid);
 

--- a/tests/behat/tool_opencast_maintenace.feature
+++ b/tests/behat/tool_opencast_maintenace.feature
@@ -90,7 +90,7 @@ Feature: Configure and check maintenance
     And I setup block plugin
     And I make sure the block drawer keeps opened
     And I am on "Course 1" course homepage with editing mode on
-    And I navigate to "Opencast API" in current page administration
+    And I navigate to "Opencast" in current page administration
     And I should see "Upload videos"
     And the following config values are set as admin:
     | maintenancemode_1                     | 2                                 | tool_opencast |

--- a/updatemetadata.php
+++ b/updatemetadata.php
@@ -55,9 +55,9 @@ if ($redirectpage == 'overviewvideos') {
 require_login($courseid, false);
 
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturl);
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('updatemetadata', 'tool_opencast'), $baseurl);
 
 // Capability check.

--- a/updatemetadata_massaction.php
+++ b/updatemetadata_massaction.php
@@ -58,9 +58,9 @@ if ($redirectpage == 'overviewvideos') {
 require_login($courseid, false);
 
 $PAGE->set_pagelayout('incourse');
-$PAGE->set_title(get_string('pluginname', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
-$PAGE->navbar->add(get_string('pluginname', 'tool_opencast'), $redirecturl);
+$PAGE->set_title(get_string('servicename', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
+$PAGE->navbar->add(get_string('servicename', 'tool_opencast'), $redirecturl);
 $PAGE->navbar->add(get_string('updatemetadata_massaction', 'tool_opencast'), $baseurl);
 
 // Capability check.

--- a/videoeditor.php
+++ b/videoeditor.php
@@ -53,7 +53,7 @@ $PAGE->set_context($context);
 
 $PAGE->set_pagelayout('incourse');
 $PAGE->set_title(get_string('videoeditor_short', 'tool_opencast'));
-$PAGE->set_heading(get_string('pluginname', 'tool_opencast'));
+$PAGE->set_heading(get_string('servicename', 'tool_opencast'));
 
 $endpoint = settings_api::get_apiurl($ocinstanceid);
 


### PR DESCRIPTION
This introduces a new language string `servicename` to replace the
occurrences of the plugin name `Opencast API` with the actual service
name `Opencast`, which is more intuitive for end-user-facing pages.


Example of the current main view (With the PR Opencast API will be replaced with Opencast):

<img width="1594" height="610" alt="moodle_tool_opencast" src="https://github.com/user-attachments/assets/aed365a0-0f3e-47ab-813d-ef17887ecf0d" />
